### PR TITLE
Package.json: missing ssh2 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "request": "^2.55.0",
     "request-progress": "^0.3.1",
     "shell-escape": "^0.2.0",
+    "ssh2": "^0.4.8",
     "through": "^2.3.7",
     "which": "^1.1.1"
   },


### PR DESCRIPTION
Fixes failure when running `t2-vm shell`
