### PR TITLE
Added a section on prerequisites to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 Command line tool to run a Tessel 2 VM for local testing.
 
+## Prerequisites
+[VirtualBox and it's extension pack](https://www.virtualbox.org/wiki/Downloads)
+
 ## Installation
-
-You will require Virtualbox.
-
 ```
 npm install -g git+https://github.com/tessel/t2-vm.git
 ```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Command line tool to run a Tessel 2 VM for local testing.
 
 ## Prerequisites
-[VirtualBox and it's extension pack](https://www.virtualbox.org/wiki/Downloads)
+[VirtualBox and its extension pack](https://www.virtualbox.org/wiki/Downloads)
 
 ## Installation
 ```


### PR DESCRIPTION
The previous version did not ask users to download the virtualbox extension pack which is required for successfully creating the VM. I learned this from my experience on OSX.
