### PR TITLE
Fixed #29, Spawning directly vboxheadless at startvm().

### DIFF
--- a/etc.js
+++ b/etc.js
@@ -52,10 +52,7 @@ function exec (p, args, opts) {
 // windows may or may not have vbox, and that depending on your flavor of Git, that shell may or may not have your Windows user %path% exported into it
 // it's much safer to just assume vbox is in the path from the create.js insurePath check on startup
 function startvm (name) {
-  return isWin ?
-    spawn('vboxheadless', ['-s', name])
-  :
-    spawn('vboxheadless', ['-s', name]);
+  return spawn('vboxheadless', ['-s', name]);
 }
 
 function seekDevice (hostname, next) {

--- a/etc.js
+++ b/etc.js
@@ -55,7 +55,7 @@ function startvm (name) {
   return isWin ?
     spawn('vboxheadless', ['-s', name])
   :
-    spawn('sh', ['vboxheadless', '-s', name]);
+    spawn('vboxheadless', ['-s', name]);
 }
 
 function seekDevice (hostname, next) {


### PR DESCRIPTION
Works on Ubuntu 14.04 and node 5.3.0.
